### PR TITLE
Update instagram config to use new instagram API

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -1345,16 +1345,15 @@
     }
   },
   "instagram": {
-    "https://api.instagram.com": {
+    "https://graph.instagram.com": {
       "__domain": {
         "auth": {
           "qs": {"access_token": "[0]"}
         }
       },
-      "[version]/{endpoint}": {
+      "{endpoint}": {
         "__path": {
           "alias": "__default",
-          "version": "v1"
         }
       }
     }


### PR DESCRIPTION
Instagram old API was shutdown, it is required to use the new one

Fixes #3 