### PR TITLE
fix: trailing comma

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -1353,7 +1353,7 @@
       },
       "{endpoint}": {
         "__path": {
-          "alias": "__default",
+          "alias": "__default"
         }
       }
     }


### PR DESCRIPTION
That trailing comma was breaking [strapi](https://github.com/strapi/strapi) build, my case at least:

```bash
[2021-01-13T09:51:34.729Z] debug ⛔️ Server wasn't able to start properly.
[2021-01-13T09:51:34.730Z] error SyntaxError: /strapi/node_modules/@purest/providers/config/providers.json: Unexpected token } in JSON at position 27052
    at JSON.parse (<anonymous>)
    at Object.Module._extensions..json (internal/modules/cjs/loader.js:797:27)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/home/carlos/Workspace/mb/strapi/node_modules/@purest/providers/index.js:2:18)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
```